### PR TITLE
swev-id: pytest-dev__pytest-10081 prevent tearDown on skipped unittest classes

### DIFF
--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -316,7 +316,9 @@ class TestCaseFunction(Function):
             # Arguably we could always postpone tearDown(), but this changes the moment where the
             # TestCase instance interacts with the results object, so better to only do it
             # when absolutely needed.
-            if self.config.getoption("usepdb") and not _is_skipped(self.obj):
+            if self.config.getoption("usepdb") and not (
+                _is_skipped(self.obj) or _is_skipped(self._testcase)
+            ):
                 self._explicit_tearDown = self._testcase.tearDown
                 setattr(self._testcase, "tearDown", lambda *args: None)
 

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1274,6 +1274,45 @@ def test_pdb_teardown_skipped(
     assert tracked == []
 
 
+@pytest.mark.parametrize(
+    "mark",
+    [
+        '@unittest.skip("skipped for reasons")',
+        '@pytest.mark.skip(reason="skipped for reasons")',
+    ],
+)
+def test_pdb_teardown_skipped_class(
+    pytester: Pytester, monkeypatch: MonkeyPatch, mark: str
+) -> None:
+    tracked: List[str] = []
+    monkeypatch.setattr(
+        pytest, "test_pdb_teardown_skipped_class", tracked, raising=False
+    )
+
+    pytester.makepyfile(
+        """
+        import unittest
+        import pytest
+
+        {mark}
+        class MyTestCase(unittest.TestCase):
+
+            def tearDown(self):
+                pytest.test_pdb_teardown_skipped_class.append(self.id())
+
+            def test_1(self):
+                pass
+
+    """.format(
+            mark=mark
+        )
+    )
+
+    result = pytester.runpytest_inprocess("--pdb")
+    result.stdout.fnmatch_lines("* 1 skipped in *")
+    assert tracked == []
+
+
 def test_async_support(pytester: Pytester) -> None:
     pytest.importorskip("unittest.async_case")
 


### PR DESCRIPTION
## Summary
- prevent TestCaseFunction from overriding tearDown when the underlying unittest.TestCase is skipped under --pdb
- add regression coverage for class-level unittest.skip and pytest.mark.skip to ensure tearDown is not triggered
- reproduction: `pytest testing/test_unittest.py::test_pdb_teardown_skipped_class --override-ini=filterwarnings=default`

## Testing
- source .venv/bin/activate && pytest testing/test_unittest.py -k pdb_teardown_skipped_class -q --override-ini=filterwarnings=default
- source .venv/bin/activate && pytest testing/test_unittest.py::test_pdb_teardown_skipped -q --override-ini=filterwarnings=default

Fixes #3
