### PR TITLE
fix(capture): swev-id: pytest-dev__pytest-5262 normalize EncodedFile mode

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -447,6 +447,10 @@ class EncodedFile(object):
         """Ensure that file.name is a string."""
         return repr(self.buffer)
 
+    @property
+    def mode(self):
+        return self.buffer.mode.replace("b", "")
+
     def __getattr__(self, name):
         return getattr(object.__getattribute__(self, "buffer"), name)
 

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -449,7 +449,17 @@ class EncodedFile(object):
 
     @property
     def mode(self):
-        return self.buffer.mode.replace("b", "")
+        """
+        Present a text-like mode to callers.
+
+        The underlying buffer is opened in binary mode (e.g., 'rb+', 'wb+')
+        during fd-level capturing. Some libraries (e.g., youtube-dl) inspect
+        file.mode to decide whether to write bytes or text. Since EncodedFile
+        expects text on Python 3, report a mode without the binary flag.
+        """
+        m = getattr(self.buffer, "mode", "")
+        return m.replace("b", "")
+
 
     def __getattr__(self, name):
         return getattr(object.__getattribute__(self, "buffer"), name)

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1220,6 +1220,11 @@ class TestStdCaptureFD(TestStdCapture):
         """
         )
 
+    def test_intermingling(self):
+        with self.getcapture() as cap:
+            os.write(1, b"1")
+            sys.stdout.write(str(2))
+            sys.stdout.flush()
             os.write(1, b"3")
             os.write(2, b"a")
             sys.stderr.write("b")

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1212,6 +1212,11 @@ class TestStdCaptureFD(TestStdCapture):
         """
         )
 
+    def test_stdout_mode(self):
+        with self.getcapture():
+            assert "b" in sys.stdout.buffer.mode
+            assert "b" not in sys.stdout.mode
+
     def test_intermingling(self):
         with self.getcapture() as cap:
             os.write(1, b"1")

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1194,6 +1194,14 @@ class TestStdCaptureFD(TestStdCapture):
     pytestmark = needsosdup
     captureclass = staticmethod(StdCaptureFD)
 
+    def test_stdout_mode(self):
+        with self.getcapture():
+            assert hasattr(sys.stdout, "buffer")
+            # underlying buffer is binary
+            assert "b" in sys.stdout.buffer.mode
+            # EncodedFile.mode should not include "b"
+            assert "b" not in sys.stdout.mode
+
     def test_simple_only_fd(self, testdir):
         testdir.makepyfile(
             """

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -1220,16 +1220,6 @@ class TestStdCaptureFD(TestStdCapture):
         """
         )
 
-    def test_stdout_mode(self):
-        with self.getcapture():
-            assert "b" in sys.stdout.buffer.mode
-            assert "b" not in sys.stdout.mode
-
-    def test_intermingling(self):
-        with self.getcapture() as cap:
-            os.write(1, b"1")
-            sys.stdout.write(str(2))
-            sys.stdout.flush()
             os.write(1, b"3")
             os.write(2, b"a")
             sys.stderr.write("b")


### PR DESCRIPTION
## Summary
- expose `EncodedFile.mode` without the binary flag
- add fd capture regression covering stdout/buffer modes

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -k "test_stdout_mode and TestStdCaptureFD" -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest testing/test_capture.py::TestStdCaptureFD::test_stdout_mode -q

Refs #6.