### PR TITLE
swev-id: pytest-dev__pytest-5631 fix sentinel identity for WeirdEq (#10)

### DIFF
--- a/src/_pytest/compat.py
+++ b/src/_pytest/compat.py
@@ -68,7 +68,12 @@ def num_mock_patch_args(function):
     if any(mock_modules):
         sentinels = [m.DEFAULT for m in mock_modules if m is not None]
         return len(
-            [p for p in patchings if not p.attribute_name and p.new in sentinels]
+            [
+                p
+                for p in patchings
+                if not p.attribute_name
+                and any(p.new is s for s in sentinels)
+            ]
         )
     return len(patchings)
 

--- a/testing/test_patch_array_sentinel.py
+++ b/testing/test_patch_array_sentinel.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+
+
+class WeirdEq:
+    class Amb:
+        def __bool__(self):
+            raise ValueError("ambiguous truth")
+
+    def __eq__(self, other):
+        return WeirdEq.Amb()
+
+
+@patch("os.path.abspath", new=WeirdEq())
+def test_collect_ok():
+    assert True


### PR DESCRIPTION
## Summary
- fix #10 by ensuring sentinel detection only uses identity checks, avoiding ambiguous equality on numpy-like sentinels
- add a minimal regression test that patches `os.path.abspath` with a WeirdEq sentinel to reproduce the failure during collection

## Reproduction snippet
```python
from unittest.mock import patch


class WeirdEq:
    class Amb:
        def __bool__(self):
            raise ValueError("ambiguous truth")

    def __eq__(self, other):
        return WeirdEq.Amb()


@patch("os.path.abspath", new=WeirdEq())
def test_collect_ok():
    assert True
```

Run with:
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest --collect-only testing/test_patch_array_sentinel.py
```

Observed failure before the fix:
```
============================= test session starts ==============================
platform linux -- Python 3.8.16, pytest-5.0.2.dev58+gcb828ebe7, py-1.11.0, pluggy-0.13.1
rootdir: /workspace/pytest, inifile: tox.ini
collected 0 items / 1 errors

==================================== ERRORS ====================================
____________ ERROR collecting testing/test_patch_array_sentinel.py _____________
testing/test_patch_array_sentinel.py:7: in __bool__
    raise ValueError("ambiguous truth")
E   ValueError: ambiguous truth
=========================== short test summary info ============================
FAILED testing/test_patch_array_sentinel.py - ValueError: ambiguous truth
!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!
=========================== 1 error in 0.04 seconds ============================
```

## Fix details
- `num_mock_patch_args` now matches sentinel replacements using `is` comparisons against the sentinel singletons instead of equality
- avoids executing user-defined `__eq__` implementations when counting sentinel arguments, restoring safe collection

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest --collect-only testing/test_patch_array_sentinel.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest testing/test_patch_array_sentinel.py`
- `flake8 src/_pytest/compat.py testing/test_patch_array_sentinel.py`