### PR TITLE
swev-id: pytest-dev__pytest-6202 | Preserve '.[' in long report headlines (remove getmodpath sanitization)

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -286,7 +286,7 @@ class PyobjMixin(PyobjContext):
             parts.append(name)
         parts.reverse()
         s = ".".join(parts)
-        return s.replace(".[", "[")
+        return s
 
     def reportinfo(self):
         # XXX caching?

--- a/testing/test_headline_modpath_param_id.py
+++ b/testing/test_headline_modpath_param_id.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+def test_headline_preserves_dot_bracket_in_param_id(testdir):
+    testdir.makepyfile(
+        **{
+            "test_sample.py": (
+                """
+                import pytest
+
+                @pytest.mark.parametrize("arg", [0], ids=["a..[b]"])
+                def test_boo(arg):
+                    assert False
+                """
+            )
+        }
+    )
+    result = testdir.runpytest("-vv")
+    # Ensure the failure headline contains the exact param id text without mutation
+    result.stdout.fnmatch_lines([
+        "*FAILURES*",
+        "*test_boo[a..[b]]*",
+    ])
+    assert result.ret != 0


### PR DESCRIPTION
Fixes #22

Summary
- Long failure headlines mutated param ids containing the substring ".[" (e.g., "..[" became ".["), breaking readability and some tooling that parses pytest output.

Root cause
- src/_pytest/python.py (PyobjMixin.getmodpath) returned `s.replace(".[", "[")`. This was originally to avoid `test_gen.[0]` names from yield-based tests (removed in pytest 4.0). It now corrupts legitimate ids.

Change
- Return the assembled modpath string unchanged.
- Add a regression test to ensure headlines preserve param ids containing `..[` sequences.

Reproduction steps
1. Create `bug.py`:
```
import pytest

@pytest.mark.parametrize("a", ["..["])
def test_boo(a):
    assert False
```
2. Run: `pytest -vv bug.py`
3. Before this fix, failure headline showed `test_boo[.[]` instead of `test_boo[..[]`.

Observed failure (before fix)
```
bug.py F                                                                 [100%]

=================================== FAILURES ===================================
_________________________________ test_boo[.[] _________________________________

a = '..['

    @pytest.mark.parametrize("a",["..["])
    def test_boo(a):
>       assert 0
E       assert 0

bug.py:6: AssertionError
============================== 1 failed in 0.06s ===============================
```

Tests
- New test `testing/test_headline_modpath_param_id.py` which runs a failing parametrized test with id `a..[b]` and asserts the -vv output includes `test_boo[a..[b]]` unchanged.

Notes
- This change does not affect nodeid semantics; it only preserves the headline/domain string. Yield tests are gone, so the previous sanitization is obsolete.
- Per instructions: not triggering CI here.