### PR TITLE
swev-id: pytest-dev__pytest-7205 fix setup-show bytes BytesWarning

### DIFF
--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -1,5 +1,7 @@
 import pytest
 
+from _pytest._io.saferepr import saferepr
+
 
 def pytest_addoption(parser):
     group = parser.getgroup("debugconfig")
@@ -66,7 +68,7 @@ def _show_fixture_action(fixturedef, msg):
             tw.write(" (fixtures used: {})".format(", ".join(deps)))
 
     if hasattr(fixturedef, "cached_param"):
-        tw.write("[{}]".format(fixturedef.cached_param))
+        tw.write("[{}]".format(saferepr(fixturedef.cached_param, maxsize=80)))
 
     tw.flush()
 

--- a/testing/test_setup_show_bytes_param.py
+++ b/testing/test_setup_show_bytes_param.py
@@ -1,0 +1,21 @@
+import sys
+
+
+def test_setup_show_parametrized_fixture_bytes_no_byteswarning(testdir):
+    p = testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture(params=[b"Hello World"])
+        def data(request):
+            return request.param
+
+        def test_data(data):
+            pass
+        """
+    )
+    # Run pytest via the Python interpreter to pass -bb so BytesWarning becomes an error.
+    result = testdir.run(sys.executable, "-bb", "-m", "pytest", "--setup-show", p)
+    assert result.ret == 0
+    # Verify that the bytes value is displayed using a repr-like format.
+    result.stdout.fnmatch_lines(["*SETUP    F data?b'Hello World'?*"])


### PR DESCRIPTION
## Summary
- import and use saferepr when rendering cached fixture parameters so `--setup-show` respects `-bb`
- add a regression test covering parametrized bytes fixtures under `--setup-show`

## Reproduction
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -bb -m pytest testing/test_setup_show_bytes_param.py
  - Before the fix this fails with `BytesWarning: str() on a bytes instance` originating from `_show_fixture_action`.

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -bb -m pytest testing/test_setup_show_bytes_param.py

Fixes #24