### PR TITLE
swev-id: pytest-dev__pytest-7236 skip deferred unittest tearDown for skips

### DIFF
--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -122,7 +122,8 @@ class TestCaseFunction(Function):
 
     def teardown(self):
         if self._explicit_tearDown is not None:
-            self._explicit_tearDown()
+            if not self._store.get(skipped_by_mark_key, False):
+                self._explicit_tearDown()
             self._explicit_tearDown = None
         self._testcase = None
         self._obj = None

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -1193,6 +1193,62 @@ def test_pdb_teardown_called(testdir, monkeypatch):
     ]
 
 
+def test_unittest_skip_method_does_not_call_teardown_with_pdb(testdir):
+    testdir.makepyfile(
+        """
+        import unittest
+
+        class MyTestCase(unittest.TestCase):
+            @unittest.skip("skip method")
+            def test_skipped(self):
+                pass
+
+            def tearDown(self):
+                raise AssertionError("tearDown should not be called")
+    """
+    )
+    result = testdir.runpytest_inprocess("--pdb")
+    result.assert_outcomes(skipped=1)
+
+
+def test_unittest_setUp_raises_SkipTest_does_not_call_teardown_with_pdb(testdir):
+    testdir.makepyfile(
+        """
+        import unittest
+
+        class MyTestCase(unittest.TestCase):
+            def setUp(self):
+                raise unittest.SkipTest("skip in setup")
+
+            def tearDown(self):
+                raise AssertionError("tearDown should not be called")
+
+            def test_something(self):
+                pass
+    """
+    )
+    result = testdir.runpytest_inprocess("--pdb")
+    result.assert_outcomes(skipped=1)
+
+
+def test_unittest_class_skip_does_not_call_teardown_with_pdb(testdir):
+    testdir.makepyfile(
+        """
+        import unittest
+
+        @unittest.skip("skip class")
+        class MyTestCase(unittest.TestCase):
+            def tearDown(self):
+                raise AssertionError("tearDown should not be called")
+
+            def test_something(self):
+                pass
+    """
+    )
+    result = testdir.runpytest_inprocess("--pdb")
+    result.assert_outcomes(skipped=1)
+
+
 def test_async_support(testdir):
     pytest.importorskip("unittest.async_case")
 


### PR DESCRIPTION
## Summary
- only execute the deferred unittest `tearDown` when the test was not skipped
- add regression coverage for skip decorators, `SkipTest` in `setUp`, and class-level skips when running with `--pdb`

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest testing/test_unittest.py -q`
- `. .venv/bin/activate && flake8 src/_pytest/unittest.py testing/test_unittest.py`

## Reproduction
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest testing/test_unittest.py::test_unittest_skip_method_does_not_call_teardown_with_pdb -q --pdb`
- Observed prior to this change: the deferred `tearDown` ran despite the skip and raised `AssertionError("tearDown should not be called")`, failing the run.

Fixes #26.