### PR TITLE
swev-id: pytest-dev__pytest-7432 fix: preserve skip item location under --runxfail

### DIFF
--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -270,13 +270,15 @@ def pytest_runtest_makereport(item: Item, call: CallInfo[None]):
         else:
             rep.longrepr = "Unexpected success"
         rep.outcome = "failed"
-    elif item.config.option.runxfail:
-        pass  # don't interfere
-    elif call.excinfo and isinstance(call.excinfo.value, xfail.Exception):
+    elif (
+        not item.config.option.runxfail
+        and call.excinfo
+        and isinstance(call.excinfo.value, xfail.Exception)
+    ):
         assert call.excinfo.value.msg is not None
         rep.wasxfail = "reason: " + call.excinfo.value.msg
         rep.outcome = "skipped"
-    elif not rep.skipped and xfailed:
+    elif (not item.config.option.runxfail) and not rep.skipped and xfailed:
         if call.excinfo:
             raises = xfailed.raises
             if raises is not None and not isinstance(call.excinfo.value, raises):

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -619,6 +619,21 @@ class TestSkip:
         result = testdir.runpytest("-rs")
         result.stdout.fnmatch_lines(["*for lolz*", "*1 skipped*"])
 
+    def test_skip_reports_item_location_with_runxfail(self, testdir):
+        testdir.makepyfile(
+            test_skip="""
+            import pytest
+
+            @pytest.mark.skip(reason="skip me")
+            def test_skip():
+                pass
+        """
+        )
+        result = testdir.runpytest("-q", "-rs", "--runxfail")
+        result.stdout.fnmatch_lines(["*test_skip.py:*: skip me*"])
+        result.stdout.no_fnmatch_line("*src/_pytest/skipping.py*")
+        assert result.ret == 0
+
     def test_only_skips_marked_test(self, testdir):
         testdir.makepyfile(
             """
@@ -677,6 +692,21 @@ class TestSkipif:
         )
         result = testdir.runpytest(p, "-s", "-rs")
         result.stdout.fnmatch_lines(["*SKIP*1*test_foo.py*platform*", "*1 skipped*"])
+        assert result.ret == 0
+
+    def test_skipif_reports_item_location_with_runxfail(self, testdir):
+        testdir.makepyfile(
+            test_skipif="""
+            import pytest
+
+            @pytest.mark.skipif(True, reason="conditional skip")
+            def test_skipif():
+                pass
+        """
+        )
+        result = testdir.runpytest("-q", "-rs", "--runxfail")
+        result.stdout.fnmatch_lines(["*test_skipif.py:*: conditional skip*"])
+        result.stdout.no_fnmatch_line("*src/_pytest/skipping.py*")
         assert result.ret == 0
 
     def test_skipif_using_platform(self, testdir):


### PR DESCRIPTION
## Summary
- guard xfail-only report branches when `--runxfail` is active so the skip-location rewrite still executes
- remove the early `--runxfail` bypass to keep skip reports tied to their test definitions

Fixes #29.

## Observed failure (pre-fix)
Commands were run from `/workspace/tmp_skip_tests` with the repo venv activated (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`).

```shell
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q -rs test_skip.py --runxfail
```
```text
s                                                                        [100%]
=========================== short test summary info ============================
SKIPPED [1] ../pytest/src/_pytest/skipping.py:239: skip me
1 skipped in 0.00s
```

```shell
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q -rs test_skipif.py --runxfail
```
```text
s                                                                        [100%]
=========================== short test summary info ============================
SKIPPED [1] ../pytest/src/_pytest/skipping.py:239: conditional skip
1 skipped in 0.00s
```

## Verification
```shell
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q -rs test_skip.py --runxfail
```
```text
s                                                                        [100%]
=========================== short test summary info ============================
SKIPPED [1] test_skip.py:4: skip me
1 skipped in 0.00s
```

```shell
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q -rs test_skipif.py --runxfail
```
```text
s                                                                        [100%]
=========================== short test summary info ============================
SKIPPED [1] test_skipif.py:4: conditional skip
1 skipped in 0.00s
```

```shell
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q -rs test_xfail.py
```
```text
x                                                                        [100%]
1 xfailed in 0.01s
```

```shell
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q -rs test_xfail.py --runxfail
```
```text
F                                                                        [100%]
=================================== FAILURES ===================================
_______________________________ test_xfail_fails _______________________________

    @pytest.mark.xfail(reason="expected failure")
    def test_xfail_fails():
>       assert False
E       assert False

test_xfail.py:6: AssertionError
1 failed in 0.01s
```

## Notes
- Direct `pytest.skip` calls continue to respect the original call site.
- `unittest`-style tests still report unexpected successes/failures exactly as before.
- CI intentionally not triggered per repository policy.