### PR TITLE
swev-id: pytest-dev__pytest-7521 preserve CR in capfd

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -388,6 +388,7 @@ class FDCaptureBinary:
                 TemporaryFile(buffering=0),  # type: ignore[arg-type]
                 encoding="utf-8",
                 errors="replace",
+                newline="",
                 write_through=True,
             )
             if targetfd in patchsysdict:

--- a/testing/test_capture_capfd_cr.py
+++ b/testing/test_capture_capfd_cr.py
@@ -1,0 +1,19 @@
+import sys
+
+
+def test_capfd_includes_carriage_return(capfd):
+    print("Greetings from DOS", end="\r")
+    out, err = capfd.readouterr()
+    assert out.endswith("\r")
+
+
+def test_capfd_preserves_crlf(capfd):
+    print("X\r\nY", end="", flush=True)
+    out, err = capfd.readouterr()
+    assert "\r\n" in out
+
+
+def test_capfd_stderr_includes_carriage_return(capfd):
+    print("Greetings from stderr", end="\r", file=sys.stderr)
+    out, err = capfd.readouterr()
+    assert err.endswith("\r")


### PR DESCRIPTION
## Summary
- disable universal newline translations in `FDCaptureBinary` to preserve carriage returns
- add regression tests for stdout/stderr CR and CRLF handling

## Issue
- Closes #32

## Regression
- Regression introduced in 29e4cb5d45f44379aba948c2cd791b3b97210e31
- Reproducer:
```python
def test_capfd_includes_carriage_return(capfd):
    print("Greetings from DOS", end="\r")
    out, err = capfd.readouterr()
    assert out.endswith("\r")
```
- Failure before fix:
```
$ PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS=--assert=plain python -m pytest -q testing/test_capture_capfd_cr.py::test_capfd_includes_carriage_return
F                                                                        [100%]
=================================== FAILURES ===================================
_____________________ test_capfd_includes_carriage_return ______________________

capfd = <_pytest.capture.CaptureFixture object at 0xffff9286a150>

    def test_capfd_includes_carriage_return(capfd):
        print('Greetings from DOS', end='\r')
        out, err = capfd.readouterr()
>       assert out.endswith('\r')
E       AssertionError

testing/test_capture_capfd_cr.py:4: AssertionError
=========================== short test summary info ============================
FAILED testing/test_capture_capfd_cr.py::test_capfd_includes_carriage_return
1 failed in 0.02s
```

## Testing
- `PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS=--assert=plain python -m pytest -q testing/test_capture_capfd_cr.py`
- `flake8 --extend-ignore=F821 src/_pytest/capture.py testing/test_capture_capfd_cr.py`