### PR TITLE
Fix caplog handler level restoration (swev-id: pytest-dev__pytest-7571)

### DIFF
--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -673,6 +673,8 @@ class LoggingPlugin:
 
     def _runtest_for(self, item: nodes.Item, when: str) -> Generator[None, None, None]:
         """Implements the internals of pytest_runtest_xxx() hook."""
+        if self.log_level is None:
+            self.caplog_handler.setLevel(logging.NOTSET)
         with catching_logs(
             self.caplog_handler, level=self.log_level,
         ) as caplog_handler, catching_logs(

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -673,7 +673,7 @@ class LoggingPlugin:
 
     def _runtest_for(self, item: nodes.Item, when: str) -> Generator[None, None, None]:
         """Implements the internals of pytest_runtest_xxx() hook."""
-        if self.log_level is None:
+        if when == "setup" and self.log_level is None:
             self.caplog_handler.setLevel(logging.NOTSET)
         with catching_logs(
             self.caplog_handler, level=self.log_level,

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -296,6 +296,37 @@ def test_caplog_nested_set_level_restores_handler(testdir):
     result.assert_outcomes(passed=2)
 
 
+def test_caplog_fixture_setup_level_reaches_test_body(testdir):
+    testdir.makepyfile(
+        """
+        import logging
+        import pytest
+
+
+        @pytest.fixture
+        def info_level(caplog):
+            caplog.set_level(logging.INFO)
+
+
+        def test_uses_fixture_level(caplog, info_level):
+            logger = logging.getLogger()
+            logger.debug('hidden debug message')
+            logger.info('visible info message')
+            assert caplog.handler.level == logging.INFO
+            assert [record.levelno for record in caplog.records] == [logging.INFO]
+            assert 'hidden debug message' not in caplog.text
+            assert 'visible info message' in caplog.text
+
+
+        def test_handler_level_restored_after_fixture(caplog):
+            assert caplog.handler.level == logging.NOTSET
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=2)
+
+
 def test_log_report_captures_according_to_config_option_upon_failure(testdir):
     """ Test that upon failure:
     (1) `caplog` succeeded to capture the DEBUG message and assert on it => No `Exception` is raised

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -236,6 +236,66 @@ def test_caplog_captures_despite_exception(testdir):
     assert result.ret == 1
 
 
+def test_caplog_handler_level_restored_between_tests(testdir):
+    testdir.makepyfile(
+        """
+        import logging
+
+        def test_sets_custom_level(caplog):
+            caplog.set_level(42)
+            assert caplog.handler.level == 42
+
+        def test_handler_level_restored(caplog):
+            assert caplog.handler.level == logging.NOTSET
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=2)
+
+
+def test_caplog_logger_specific_override_restores_handler_level(testdir):
+    testdir.makepyfile(
+        """
+        import logging
+
+        def test_override_specific_logger(caplog):
+            logger = logging.getLogger('example')
+            caplog.set_level(logging.WARNING, logger=logger.name)
+            logger.warning('message')
+            assert caplog.handler.level == logging.WARNING
+            assert [record.levelno for record in caplog.records] == [logging.WARNING]
+
+        def test_handler_level_after_logger_override(caplog):
+            assert caplog.handler.level == logging.NOTSET
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=2)
+
+
+def test_caplog_nested_set_level_restores_handler(testdir):
+    testdir.makepyfile(
+        """
+        import logging
+
+        def test_nested_set_level(caplog):
+            caplog.set_level(logging.INFO)
+            caplog.set_level(logging.DEBUG)
+            with caplog.at_level(logging.WARNING):
+                logging.getLogger().warning('inside')
+            assert caplog.handler.level == logging.DEBUG
+
+        def test_handler_level_after_nested_set_level(caplog):
+            assert caplog.handler.level == logging.NOTSET
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=2)
+
+
 def test_log_report_captures_according_to_config_option_upon_failure(testdir):
     """ Test that upon failure:
     (1) `caplog` succeeded to capture the DEBUG message and assert on it => No `Exception` is raised


### PR DESCRIPTION
## Summary
- ensure the shared caplog handler is reset to `NOTSET` when no global log level is configured
- add regression tests covering handler level restoration across default, logger-specific, and nested overrides
- fixes #35

## Observed Failure and Reproduction
- on the base branch, create two tests where the first calls `caplog.set_level(42)` and the second asserts `caplog.handler.level == logging.NOTSET`
- the second test inherits level 42 from the previous run, causing assertions and log capture expectations to fail without any stack trace (state leakage only)

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest testing/logging/test_fixture.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest testing/logging
- .venv/bin/flake8 src/_pytest/logging.py testing/logging/test_fixture.py