### PR TITLE
swev-id: pytest-dev__pytest-8399

### DIFF
--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -528,7 +528,7 @@ class Module(nodes.File, PyCollector):
             autouse=True,
             scope="module",
             # Use a unique name to speed up lookup.
-            name=f"xunit_setup_module_fixture_{self.obj.__name__}",
+            name=f"_xunit_setup_module_fixture_{self.obj.__name__}",
         )
         def xunit_setup_module_fixture(request) -> Generator[None, None, None]:
             if setup_module is not None:
@@ -557,7 +557,7 @@ class Module(nodes.File, PyCollector):
             autouse=True,
             scope="function",
             # Use a unique name to speed up lookup.
-            name=f"xunit_setup_function_fixture_{self.obj.__name__}",
+            name=f"_xunit_setup_function_fixture_{self.obj.__name__}",
         )
         def xunit_setup_function_fixture(request) -> Generator[None, None, None]:
             if request.instance is not None:
@@ -809,7 +809,7 @@ class Class(PyCollector):
             autouse=True,
             scope="class",
             # Use a unique name to speed up lookup.
-            name=f"xunit_setup_class_fixture_{self.obj.__qualname__}",
+            name=f"_xunit_setup_class_fixture_{self.obj.__qualname__}",
         )
         def xunit_setup_class_fixture(cls) -> Generator[None, None, None]:
             if setup_class is not None:
@@ -838,7 +838,7 @@ class Class(PyCollector):
             autouse=True,
             scope="function",
             # Use a unique name to speed up lookup.
-            name=f"xunit_setup_method_fixture_{self.obj.__qualname__}",
+            name=f"_xunit_setup_method_fixture_{self.obj.__qualname__}",
         )
         def xunit_setup_method_fixture(self, request) -> Generator[None, None, None]:
             method = request.function

--- a/src/_pytest/unittest.py
+++ b/src/_pytest/unittest.py
@@ -144,7 +144,7 @@ def _make_xunit_fixture(
         scope=scope,
         autouse=True,
         # Use a unique name to speed up lookup.
-        name=f"unittest_{setup_name}_fixture_{obj.__qualname__}",
+        name=f"_unittest_{setup_name}_fixture_{obj.__qualname__}",
     )
     def fixture(self, request: FixtureRequest) -> Generator[None, None, None]:
         if _is_skipped(self):

--- a/testing/python/test_unittest_xunit_fixture_visibility.py
+++ b/testing/python/test_unittest_xunit_fixture_visibility.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import textwrap
+
+
+def _run(pytester, *args):
+    return pytester.runpytest("--assert=plain", *args)
+
+
+def test_unittest_autouse_fixture_hidden_by_default(pytester) -> None:
+    test_module = pytester.makepyfile(
+        textwrap.dedent(
+            """
+            import unittest
+
+
+            class SampleTest(unittest.TestCase):
+                @classmethod
+                def setUpClass(cls):
+                    pass
+
+                def test_dummy(self):
+                    pass
+            """
+        )
+    )
+
+    default = _run(pytester, "--fixtures", str(test_module))
+    default.stdout.no_fnmatch_line("*_unittest_setUpClass_fixture_*")
+
+    verbose = _run(pytester, "-v", "--fixtures", str(test_module))
+    verbose.stdout.fnmatch_lines_random(
+        ["*_unittest_setUpClass_fixture_* -- */_pytest/unittest.py:*"]
+    )
+
+    per_test = _run(pytester, "--fixtures-per-test", str(test_module))
+    per_test.stdout.no_fnmatch_line("*_unittest_setUpClass_fixture_*")
+
+    per_test_verbose = _run(
+        pytester, "-v", "--fixtures-per-test", str(test_module)
+    )
+    per_test_verbose.stdout.fnmatch_lines_random(
+        ["*_unittest_setUpClass_fixture_* -- */_pytest/unittest.py:*"]
+    )
+
+
+def test_xunit_autouse_fixtures_hidden_by_default(pytester) -> None:
+    test_module = pytester.makepyfile(
+        textwrap.dedent(
+            """
+            values = []
+
+
+            def setup_module(module):
+                values.append("module")
+
+
+            def teardown_module(module):
+                values.append("teardown_module")
+
+
+            class TestSample:
+                @classmethod
+                def setup_class(cls):
+                    values.append("class")
+
+                @classmethod
+                def teardown_class(cls):
+                    values.append("teardown_class")
+
+                def setup_method(self, method):
+                    values.append("method")
+
+                def teardown_method(self, method):
+                    values.append("teardown_method")
+
+                def test_dummy(self):
+                    pass
+            """
+        )
+    )
+
+    hidden_patterns = [
+        "*_xunit_setup_module_fixture_*",
+        "*_xunit_setup_class_fixture_*",
+        "*_xunit_setup_method_fixture_*",
+    ]
+    visible_patterns = [
+        "*_xunit_setup_module_fixture_* -- */_pytest/python.py:*",
+        "*_xunit_setup_class_fixture_* -- */_pytest/python.py:*",
+        "*_xunit_setup_method_fixture_* -- */_pytest/python.py:*",
+    ]
+
+    default = _run(pytester, "--fixtures", str(test_module))
+    for pattern in hidden_patterns:
+        default.stdout.no_fnmatch_line(pattern)
+
+    verbose = _run(pytester, "-v", "--fixtures", str(test_module))
+    verbose.stdout.fnmatch_lines_random(visible_patterns)
+
+    per_test = _run(pytester, "--fixtures-per-test", str(test_module))
+    for pattern in hidden_patterns:
+        per_test.stdout.no_fnmatch_line(pattern)
+
+    per_test_verbose = _run(pytester, "-v", "--fixtures-per-test", str(test_module))
+    per_test_verbose.stdout.fnmatch_lines_random(visible_patterns)


### PR DESCRIPTION
## Summary
- prefix autogenerated unittest/xunit fixtures with an underscore to hide them by default
- add regression coverage ensuring fixtures become visible with -v listings

## Testing
- PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS=--assert=plain pytest testing/python/test_unittest_xunit_fixture_visibility.py -q
- flake8 src/_pytest/unittest.py src/_pytest/python.py testing/python/test_unittest_xunit_fixture_visibility.py

## Reproduction Steps
- pytest --fixtures  # no stack trace; visibility regression only

Resolves #37.