### PR TITLE
fix: setup-show bytes param repr (swev-id: pytest-dev__pytest-7205)

### DIFF
--- a/src/_pytest/setuponly.py
+++ b/src/_pytest/setuponly.py
@@ -1,5 +1,7 @@
 import pytest
 
+from _pytest._io.saferepr import saferepr
+
 
 def pytest_addoption(parser):
     group = parser.getgroup("debugconfig")
@@ -66,7 +68,7 @@ def _show_fixture_action(fixturedef, msg):
             tw.write(" (fixtures used: {})".format(", ".join(deps)))
 
     if hasattr(fixturedef, "cached_param"):
-        tw.write("[{}]".format(fixturedef.cached_param))
+        tw.write("[{}]".format(saferepr(fixturedef.cached_param)))
 
     tw.flush()
 

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -293,8 +293,7 @@ def test_setup_show_with_KeyboardInterrupt_in_test(testdir):
     )
     assert result.ret == ExitCode.INTERRUPTED
 
-
-def test_setup_show_parametrize_bytes(testdir):
+def test_setup_show_parametrize_bytes_does_not_raise_bytes_warning(testdir):
     p = testdir.makepyfile(
         """
         import pytest
@@ -304,13 +303,12 @@ def test_setup_show_parametrize_bytes(testdir):
             pass
     """
     )
-
-    result = testdir.runpytest("--setup-show", p)
+    result = testdir.runpytest_subprocess("--setup-show", p)
     result.stdout.fnmatch_lines(
         [
-            "*SETUP    F data*[b'Hello World']*",
-            "*test_data[data0]*",
-            "*TEARDOWN F data*[b'Hello World']*",
+            "*SETUP    F data[b'Hello World']*",
+            "*test_data[b'Hello World'] (fixtures used: data)*",
+            "*TEARDOWN F data[b'Hello World']*",
             "*= 1 passed in *",
         ]
     )

--- a/testing/test_setuponly.py
+++ b/testing/test_setuponly.py
@@ -292,3 +292,25 @@ def test_setup_show_with_KeyboardInterrupt_in_test(testdir):
         ]
     )
     assert result.ret == ExitCode.INTERRUPTED
+
+
+def test_setup_show_parametrize_bytes(testdir):
+    p = testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.parametrize('data', [b'Hello World'])
+        def test_data(data):
+            pass
+    """
+    )
+
+    result = testdir.runpytest("--setup-show", p)
+    result.stdout.fnmatch_lines(
+        [
+            "*SETUP    F data*[b'Hello World']*",
+            "*test_data[data0]*",
+            "*TEARDOWN F data*[b'Hello World']*",
+            "*= 1 passed in *",
+        ]
+    )


### PR DESCRIPTION
Fixes a `BytesWarning` when running `--setup-show` with bytes fixture params under `-bb`.

### What changed
- Use `_pytest._io.saferepr.saferepr` when writing `fixturedef.cached_param` in `src/_pytest/setuponly.py`.
- Add a regression test in `testing/test_setuponly.py` for parametrized bytes under `--setup-show`.

### Notes
- Kept change minimal and localized to setup-show output formatting.
- Related issue: #7205

### Local validation
- Ran targeted tests locally (see test summary comment).