### PR TITLE
fix(skipping): respect xfail markers added dynamically during test execution

### DIFF
--- a/src/_pytest/skipping.py
+++ b/src/_pytest/skipping.py
@@ -239,7 +239,9 @@ def pytest_runtest_setup(item: Item) -> None:
         skip(skipped.reason)
 
     if not item.config.option.runxfail:
-        item._store[xfailed_key] = xfailed = evaluate_xfail_marks(item)
+        xfailed = evaluate_xfail_marks(item)
+        if xfailed is not None:
+            item._store[xfailed_key] = xfailed
         if xfailed and not xfailed.run:
             xfail("[NOTRUN] " + xfailed.reason)
 
@@ -247,8 +249,10 @@ def pytest_runtest_setup(item: Item) -> None:
 @hookimpl(hookwrapper=True)
 def pytest_runtest_call(item: Item) -> Generator[None, None, None]:
     xfailed = item._store.get(xfailed_key, None)
-    if xfailed is None:
-        item._store[xfailed_key] = xfailed = evaluate_xfail_marks(item)
+    if xfailed is None and not item.config.option.runxfail:
+        xfailed = evaluate_xfail_marks(item)
+        if xfailed and not xfailed.run:
+            item._store[xfailed_key] = xfailed
 
     if not item.config.option.runxfail:
         if xfailed and not xfailed.run:
@@ -262,6 +266,8 @@ def pytest_runtest_makereport(item: Item, call: CallInfo[None]):
     outcome = yield
     rep = outcome.get_result()
     xfailed = item._store.get(xfailed_key, None)
+    if xfailed is None and call.when == "call" and not item.config.option.runxfail:
+        xfailed = evaluate_xfail_marks(item)
     # unittest special case, see setting of unexpectedsuccess_key
     if unexpectedsuccess_key in item._store and rep.when == "call":
         reason = item._store[unexpectedsuccess_key]

--- a/testing/test_skipping.py
+++ b/testing/test_skipping.py
@@ -425,6 +425,18 @@ class TestXFail:
         result = testdir.runpytest(p)
         result.stdout.fnmatch_lines(["*1 xfailed*"])
 
+    def test_dynamic_xfail_set_during_test(self, testdir):
+        p = testdir.makepyfile(
+            """
+            import pytest
+            def test_this(request):
+                request.node.add_marker(pytest.mark.xfail(reason="xfail"))
+                assert 0
+        """
+        )
+        result = testdir.runpytest(p, "-rxs")
+        result.stdout.fnmatch_lines(["*XFAIL*", "*xfail*", "*1 xfailed*"])
+
     @pytest.mark.parametrize(
         "expected, actual, matchline",
         [


### PR DESCRIPTION
## Summary

This PR fixes the issue where dynamically adding an `xfail` marker inside a test body via `request.node.add_marker()` no longer correctly converts the failure to XFAIL in pytest 6.x.

Fixes #33

## Problem

In pytest 5.x, adding an `xfail` marker dynamically in a test worked correctly:

```python
def test_xfail_test(request):
    mark = pytest.mark.xfail(reason="xfail")
    request.node.add_marker(mark)
    assert 0
```

This would result in XFAIL. However, in pytest 6.x, the test fails instead.

## Root Cause

The regression was introduced by commit c9737ae914891027da5f0bd39494dd51a3b3f19f ("skipping: simplify xfail handling during call phase") which cached the xfail evaluation early, preventing dynamically added xfail marks during the call phase from affecting the test outcome.

## Solution

The fix modifies the xfail evaluation logic in `src/_pytest/skipping.py`:

1. **`pytest_runtest_setup`**: Only store xfailed in `item._store` when it's not `None`. This prevents prematurely marking that no xfail exists.

2. **`pytest_runtest_call`**: Re-evaluate for `run=False` markers that may have been added in fixtures, but don't store the result unconditionally. This allows test-body-added markers to be caught later.

3. **`pytest_runtest_makereport`**: If xfailed is `None` during the call phase, re-evaluate now to catch dynamically added markers before converting the outcome.

## Testing

Added a new test `test_dynamic_xfail_set_during_test` to verify the fix.

## Test & Lint Summary

- **Linting**: `flake8 src/_pytest/skipping.py testing/test_skipping.py` - no errors
- **Formatting**: `black --check src/_pytest/skipping.py testing/test_skipping.py` - all files pass
- **Tests**: All xfail-related tests pass including the new test for dynamically added markers

Note: Test suite is run with `--assert=plain` due to Python 3.11 AST incompatibility with this older pytest branch.